### PR TITLE
Fix duplicate posts in getPostsForTimeline service

### DIFF
--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -42,7 +42,11 @@ module.exports = {
           posts.like_counter,
           posts.created_at,
           case 
-            when favorite_posts.user_id = ? then 1 
+            when (
+              select id from favorite_posts 
+              where post_id = posts.id and user_id = ?
+              limit 1
+            ) is not null then 1 
             else 0
           end as liked_by_user,
           null as group_name,
@@ -53,8 +57,6 @@ module.exports = {
           on posts.user_id = followers.target_user_id
         inner join users
           on posts.user_id = users.id
-        left join favorite_posts
-          on posts.id = favorite_posts.post_id
         where 
           followers.follower_user_id = ? and 
           (posts.post_type = 'user' or
@@ -74,7 +76,11 @@ module.exports = {
           posts.like_counter,
           posts.created_at,
           case 
-            when favorite_posts.user_id = ? then 1 
+            when (
+              select id from favorite_posts 
+              where post_id = posts.id and user_id = ?
+              limit 1
+            ) is not null then 1  
             else 0
           end as liked_by_user,
           user_groups.name as group_name,
@@ -89,8 +95,6 @@ module.exports = {
           on group_memberships.group_id = user_groups.id
         inner join users
           on posts.user_id = users.id
-        left join favorite_posts
-          on posts.id = favorite_posts.post_id
         where 
           group_memberships.user_id = ? and
           posts.user_id != ?
@@ -99,7 +103,7 @@ module.exports = {
       order by created_at desc
       limit ?, ?;
     `
-    // Counts how much records there are.
+    // Prepare query to counts how much records there are.
     let countQuery = query.split('\n')
     // Remove selected fields and select the amount of records.
     countQuery.splice(2, 14, 'count(*) as total_records')

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -89,10 +89,10 @@ module.exports = {
         from posts
         inner join group_posts
           on posts.id = group_posts.post_id
-        inner join group_memberships
-          on group_posts.group_id = group_memberships.group_id
         inner join user_groups
-          on group_memberships.group_id = user_groups.id
+          on group_posts.group_id = user_groups.id
+        inner join group_memberships
+          on user_groups.id = group_memberships.group_id
         inner join users
           on posts.user_id = users.id
         where 


### PR DESCRIPTION
When more than 1 user marked as favorite a certain post, the left join (removed) returned the post x times marked as favorite.

This error can be observed using the user id 2 and 3 of the test DB, users who have marked as favorite the post 9, it appears repeated in their timeline