### PR TITLE
Replaced API to get permissons of a group by an API to get information of a group

### DIFF
--- a/docs/WEB_SERVICES.md
+++ b/docs/WEB_SERVICES.md
@@ -17,7 +17,7 @@
     * [Get public user types](#get-public-user-types)
     * [Get majors data](#get-majors-data)
   * [Groups](#groups)
-    * [Get permission of a group](#get-permission-of-a-group)
+    * [Get information of a group](#get-information-of-a-group)
     * [Search groups](#search-groups)
     * [Create a group](#create-a-group)
     * [Switch group notifications](#switch-group-notifications)
@@ -423,15 +423,15 @@ No particular codes.
 
 ### Groups
 
-#### Get permission of a group
+#### Get information of a group
 
 ##### Description
 
-Return the permissions that a group has.
+Return information about a certain group.
 
 ##### Endpoint
 
-`/v1/api/social-network/groups/group/:group_id/permissions`
+`/v1/api/social-network/groups/group/:group_id/information`
 
 ##### Headers
 
@@ -449,6 +449,17 @@ GET
 
 ```json
 {
+  "group_data": {
+    "owner_firstname": "Jhon",
+    "owner_lastname": "Doe",
+    "owner_username": "jhondoe",
+    "owner_profile_img_src": "",
+    "group_name": "Engineering",
+    "group_image_src": "",
+    "group_description": "Python where we can, C++ where we must.",
+    "group_visibility": "public",
+    "group_created_at": "2021-07-04T22:37:15.000Z"
+  },
   "permissions": [
     {
       "id": 1,
@@ -461,6 +472,11 @@ GET
       "name": "Permitir comentarios",
       "codename": "allow_comments",
       "granted": 0
+    }
+  ],
+  "tags": [
+    {
+      "tag": "Ciencia"
     }
   ]
 }

--- a/docs/services/GROUP.md
+++ b/docs/services/GROUP.md
@@ -72,6 +72,8 @@ Return information of a group such as who is its owner, name, image, permissions
     - codename: string
   - tags: Object[]
     - tag: string
+* **Exit code**:
+  * 1: Group doesn't exists.
 
 ### `searchGroups`
 

--- a/docs/services/GROUP.md
+++ b/docs/services/GROUP.md
@@ -6,6 +6,7 @@
 * [Methods](#Methods)
   * [getGroupPermissions](#getGroupPermissions)
   * [getAvailableGroupPermissions](#getavailablegrouppermissions)
+  * [getGroupInformation](#getgroupinformation)
   * [searchGroups](#searchGroups)
   * [createGroup](#createGroup)
   * [switchGroupNotifications](#switchGroupNotifications)
@@ -45,6 +46,32 @@ Return an array of available permissions that can be assigned to a group.
   * `id`: int. 
   * `name`: string
   * `codename`: string.
+
+### `getGroupInformation`
+
+* **Description**
+
+Return information of a group such as who is its owner, name, image, permissions, tags and so on.
+
+* **Params**:
+  * `groupId`: int
+* **Return data type**: Promise\<Object>
+  - exit_code: int
+  - groupData: Objetc
+    - owner_firstname: string
+    - owner_firstname: string
+    - owner_profile_img_src: string
+    - group_name: string
+    - group_image_src: string
+    - group_description: string
+    - group_visibility: string
+    - group_created_at: string
+  - permissions: Object[]
+    - id: number
+    - name: string
+    - codename: string
+  - tags: Object[]
+    - tag: string
 
 ### `searchGroups`
 

--- a/src/apis/social_network/controllers/groups.controller.js
+++ b/src/apis/social_network/controllers/groups.controller.js
@@ -4,20 +4,22 @@ const errorHandlingService = require('../../../services/error_handling.service')
 const messages = require('../../../../etc/messages.json')
 
 module.exports = {
-  getGroupPermissions: async function(req, res) {
+  getGroupInformation: async function(req, res) {
     try {
-      let groupPerm = await groupService.getGroupPermissions(req.params.group_id)
-      let code = groupPerm.exists_group ? 0 : 1
+      let groupPerm = await groupService.getGroupInformation(req.params.group_id)
+      let code = groupPerm.exit_code
       res.finish({
         code,
         messages: code == 0 ? ['Done'] : ['Group does not exist'],
         data: {
-          permissions: code == 0 ? groupPerm.permissions : []
+          group_data: groupPerm.groupData,
+          permissions: groupPerm.permissions,
+          tags: groupPerm.tags
         }
       })
     } catch(err) {
       err.file = err.file || __filename
-      err.func = err.func || 'getGroupPermissions'
+      err.func = err.func || 'getGroupInformation'
       errorHandlingService.handleErrorInRequest(req, res, err)
     }
   },

--- a/src/apis/social_network/endpoints/groups.endpoint.js
+++ b/src/apis/social_network/endpoints/groups.endpoint.js
@@ -1,7 +1,7 @@
 const router = require('express').Router()
 const groupsFlow = require('../flows/groups.flow')
 
-router.get('/group/:group_id/permissions', groupsFlow.getGroupPermissions)
+router.get('/group/:group_id/information', groupsFlow.getGroupInformation)
 router.get('/search', groupsFlow.searchGroups)
 router.post('/create', groupsFlow.createGroup)
 router.put('/group/:group_id/switch-notifications', groupsFlow.switchGroupNotifications)

--- a/src/apis/social_network/flows/groups.flow.js
+++ b/src/apis/social_network/flows/groups.flow.js
@@ -7,10 +7,10 @@ const groupsMiddleware = require('../../../middlewares/groups.middleware')
 const upload = multer({dest: 'uploads/'})
 
 module.exports = {
-  getGroupPermissions: [
+  getGroupInformation: [
     generalMiddleware.verifyAPIKey,
     groupsMiddleware.checkGroupId,
-    groupsController.getGroupPermissions
+    groupsController.getGroupInformation
   ],
 
   searchGroups: [

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -226,7 +226,9 @@ module.exports = {
         tags: groupTags
       }
     } catch(err) {
-      //
+      err.file = __filename
+      err.func = 'getGroupInformation'
+      throw err
     }
   },
 


### PR DESCRIPTION
Replaced API to get permissons of a group by an API to get information of a group, which returns permissions, tags and other data about a gorup.