### PR TITLE
Switched from Multer to express-fileupload library to handle file uploads.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -268,6 +268,32 @@
         "vary": "~1.1.2"
       }
     },
+    "express-fileupload": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.2.1.tgz",
+      "integrity": "sha512-fWPNAkBj+Azt9Itmcz/Reqdg3LeBfaXptDEev2JM8bCC0yDptglCnlizhf0YZauyU5X/g6v7v4Xxqhg8tmEfEA==",
+      "requires": {
+        "busboy": "^0.3.1"
+      },
+      "dependencies": {
+        "busboy": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+          "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+          "requires": {
+            "dicer": "0.3.0"
+          }
+        },
+        "dicer": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+          "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+          "requires": {
+            "streamsearch": "0.1.2"
+          }
+        }
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cloudinary": "^1.22.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "express-fileupload": "^1.2.1",
     "jsonwebtoken": "^8.5.1",
     "mariadb": "^2.4.1",
     "moment": "^2.27.0",

--- a/src/apis/social_network/controllers/users.controller.js
+++ b/src/apis/social_network/controllers/users.controller.js
@@ -124,7 +124,11 @@ module.exports = {
   createPost: async function(req, res) {
     const post = {
       content: req.body.content,
-      image: req.file
+    }
+    if(req.files && req.files.image) {
+      post.image = {
+        path: req.files.image.tempFilePath
+      }
     }
     const referencedPostId = req.body.referenced_post_id
     if (!referencedPostId && !post.content && !post.image) {

--- a/src/apis/social_network/flows/users.flow.js
+++ b/src/apis/social_network/flows/users.flow.js
@@ -1,10 +1,15 @@
-const multer = require('multer')
+const fileUpload = require('express-fileupload')
 const generalMidd = require('../../../middlewares/general.middleware')
 const userMidd = require('../../../middlewares/users.middleware')
 const userCtrl = require('../controllers/users.controller')
 
-// Multer settings.
-const upload = multer({dest: 'uploads/'})
+const rootDir = process.env.ACADEMIC_NETWORK_BACKEND_ROOTDIR
+// FileUpload settings.
+const fileUploadMidd = fileUpload({
+  useTempFiles : true,
+  tempFileDir : `${rootDir}/uploads/`,
+  safeFileNames: true
+})
 
 module.exports = {
   signup: [
@@ -29,7 +34,7 @@ module.exports = {
   post: [
     generalMidd.verifyAPIKey,
     generalMidd.userAuth,
-    upload.single('image'),
+    fileUploadMidd,
     userMidd.checkNewPostData,
     userCtrl.createPost
   ],

--- a/src/middlewares/users.middleware.js
+++ b/src/middlewares/users.middleware.js
@@ -99,11 +99,15 @@ module.exports = {
       obj('referenced_post_id').isNumber().integer().isPositive()
     })
 
-    // Multer will use the 'image' field, if a file is sent in this field multer will 
-    // "send the image" in req.file so req.body.image will have undefined value, but 
-    // if a file is not sent in the field 'image' req.file will be undefined and 
+    // FileUploader will use the 'image'-named field, if a file is sent in this field FileUploader
+    // will "send the image" in req.files.image so req.body.image will have undefined value, but 
+    // if a file is not sent in the field 'image' req.files.image will be undefined and 
     // req.body.image will have a value so it is necessary to validate it.
-    validator(req.file).isObject().display('image')
+    //If no file is sent, req.files will be undefined as well.
+    if(!req.files) {
+      req.files = {}
+    }
+    validator(req.files.image).isObject().display('image')
     if (req.body.image) {
       validator(req.body.image).isObject().display('image')
     }


### PR DESCRIPTION
This library is being used in API to create user posts. Multer is yet installed.

This decision was taken due to bugs in Multer library. Sometimes Multer cannot detect files into the request body.

Lib docs: https://www.npmjs.com/package/express-fileupload