### PR TITLE
Update responses of API's related to posts

### DIFF
--- a/src/apis/social_network/controllers/groups.controller.js
+++ b/src/apis/social_network/controllers/groups.controller.js
@@ -204,19 +204,25 @@ module.exports = {
       //Retrieve post data.
       let newPostData = {}
 
-      if(resultPost.exit_code == 0) {
+      if (resultPost.exit_code == 0) {
         newPostData = await postService.getPostData(
-          resultPost.post_data.post_id,
-          true,
-          req.api.userId)
-      }
-      
-      if(newPostData.referenced_post_id) {
-        let referencedPost = await postService.getPostData(
-          newPostData.referenced_post_id,
-          false,
-          req.api.userId)
-        newPostData.referenced_post = referencedPost
+          resultPost.post_data.post_id, 
+          true, 
+          req.api.userId
+        )
+        if (newPostData.referenced_post_id) {
+          let referencedPost = await postService.getPostData(
+            newPostData.referenced_post_id,
+            false,
+            req.api.userId
+          )
+          newPostData.referenced_post = referencedPost
+          newPostData.referenced_post.liked_by_user = !!newPostData.referenced_post.liked_by_user
+        } else {
+          newPostData.referenced_pos = null
+        }
+        delete newPostData.referenced_post_id
+        newPostData.liked_by_user = !!newPostData.liked_by_user
       }
       //END Retrieve post data.
       

--- a/src/apis/social_network/controllers/posts.controller.js
+++ b/src/apis/social_network/controllers/posts.controller.js
@@ -15,9 +15,14 @@ module.exports = {
       
       for (let i = 0; i < posts.length; i++) {
         let post = posts[i]
-        post.referenced_post = (post.referenced_post_id != null) ? 
-          await postService.getPostData(post.referenced_post_id, false, req.api.userId) : null
-        post.referenced_post_id = undefined
+        if (post.referenced_post_id != null) {
+          post.referenced_post = await postService.getPostData(post.referenced_post_id, false, req.api.userId)
+          post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
+        } else {
+          post.referenced_post = null
+        }
+        delete post.referenced_post_id
+        post.liked_by_user = !!post.liked_by_user
       }
 
       res.finish({
@@ -57,8 +62,12 @@ module.exports = {
           const post = await postService.getPostData(postId, true, userId)
           if (post.referenced_post_id != null) {
             post.referenced_post = await postService.getPostData(post.referenced_post_id, false, userId)
+            post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
+          } else {
+            post.referenced_post = null
           }
-          post.referenced_post_id = undefined
+          delete post.referenced_post_id
+          post.liked_by_user = !!post.liked_by_user
           return res.finish({
             code: 0,
             messages: [messages.success_messages.c200],
@@ -81,8 +90,12 @@ module.exports = {
       }
       if (post.referenced_post_id != null) {
         post.referenced_post = await postService.getPostData(post.referenced_post_id, false, userId)
+        post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
+      } else {
+        post.referenced_post = null
       }
-      post.referenced_post_id = undefined
+      delete post.referenced_post_id
+      post.liked_by_user = !!post.liked_by_user
       return res.finish({
         code: 0,
         messages: [messages.success_messages.c200],
@@ -107,9 +120,18 @@ module.exports = {
       
       for (let i = 0; i < posts.length; i++) {
         let post = posts[i]
-        post.referenced_post = (post.referenced_post_id != null) ? 
-          await postService.getPostData(post.referenced_post_id, false) : null
-        post.referenced_post_id = undefined
+        if (post.referenced_post_id != null) {
+          post.referenced_post = await postService.getPostData(
+            post.referenced_post_id, 
+            false, 
+            req.api.userId
+          )
+          post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
+        } else {
+          post.referenced_post = null
+        }
+        delete post.referenced_post_id
+        post.liked_by_user = !!post.liked_by_user
       }
 
       res.finish({
@@ -206,8 +228,13 @@ module.exports = {
       
       for (let i = 0; i < posts.length; i++) {
         let post = posts[i]
-        post.referenced_post = (post.referenced_post_id != null) ? 
-          await postService.getPostData(post.referenced_post_id, false, req.api.userId) : null
+        if (post.referenced_post_id != null) {
+          post.referenced_post = await postService.getPostData(post.referenced_post_id, false, req.api.userId)
+          post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
+          
+        } else {
+          post.referenced_post = null
+        }
         delete post.referenced_post_id
         post.liked_by_user = !!post.liked_by_user
       }

--- a/src/apis/social_network/controllers/posts.controller.js
+++ b/src/apis/social_network/controllers/posts.controller.js
@@ -3,6 +3,39 @@ const groupService = require('../../../services/group.service')
 const errorHandlingService = require('../../../services/error_handling.service')
 const messages = require('../../../../etc/messages.json')
 
+/**
+ * Prepares the array of posts that will be send in some API response.
+ * Does the following changes for every post in the array:
+ * If the post has a referenced post then:
+ *  - Gets the post data of the referenced post and insert the data in 
+ *  the referenced_post property.
+ *  - liked_by_user property is changed to a boolean value.
+ * If the post does not have a referenced post then the referenced_post property
+ * will be null.
+ * For every post, the referenced_post_id property is deleted from the response
+ * and the liked_by_user property is changed to a boolean value.
+ * @param {Array<Object>} posts 
+ * @param {number} userId 
+ */
+async function preparePosts(posts, userId) {
+  const lengthPosts = posts.length
+  for (let i = 0; i < lengthPosts; i++) {
+    let post = posts[i]
+    if (post.referenced_post_id != null) {
+      post.referenced_post = await postService.getPostData(
+        post.referenced_post_id, 
+        false, 
+        userId
+      )
+      post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
+    } else {
+      post.referenced_post = null
+    }
+    delete post.referenced_post_id
+    post.liked_by_user = !!post.liked_by_user
+  }
+}
+
 module.exports = {
   getPostsForTimeline: async function(req, res) {
     try {
@@ -12,18 +45,7 @@ module.exports = {
         req.query.page
       )
       let posts = result.posts
-      
-      for (let i = 0; i < posts.length; i++) {
-        let post = posts[i]
-        if (post.referenced_post_id != null) {
-          post.referenced_post = await postService.getPostData(post.referenced_post_id, false, req.api.userId)
-          post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
-        } else {
-          post.referenced_post = null
-        }
-        delete post.referenced_post_id
-        post.liked_by_user = !!post.liked_by_user
-      }
+      await preparePosts(posts, req.api.userId)
 
       res.finish({
         code: 0,
@@ -117,22 +139,7 @@ module.exports = {
         req.query.page
       )
       let posts = result.posts
-      
-      for (let i = 0; i < posts.length; i++) {
-        let post = posts[i]
-        if (post.referenced_post_id != null) {
-          post.referenced_post = await postService.getPostData(
-            post.referenced_post_id, 
-            false, 
-            req.api.userId
-          )
-          post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
-        } else {
-          post.referenced_post = null
-        }
-        delete post.referenced_post_id
-        post.liked_by_user = !!post.liked_by_user
-      }
+      await preparePosts(posts, req.api.userId)
 
       res.finish({
         code: 0,
@@ -225,19 +232,7 @@ module.exports = {
       }
 
       let posts = postsRes.group_posts
-      
-      for (let i = 0; i < posts.length; i++) {
-        let post = posts[i]
-        if (post.referenced_post_id != null) {
-          post.referenced_post = await postService.getPostData(post.referenced_post_id, false, req.api.userId)
-          post.referenced_post.liked_by_user = !!post.referenced_post.liked_by_user
-          
-        } else {
-          post.referenced_post = null
-        }
-        delete post.referenced_post_id
-        post.liked_by_user = !!post.liked_by_user
-      }
+      await preparePosts(posts, req.api.userId)
 
       res.finish({
         code: 0,

--- a/src/apis/social_network/controllers/users.controller.js
+++ b/src/apis/social_network/controllers/users.controller.js
@@ -150,19 +150,25 @@ module.exports = {
       //Retrieve post data.
       let newPostData = {}
 
-      if(resultPost.exit_code == 0) {
+      if (resultPost.exit_code == 0) {
         newPostData = await postService.getPostData(
-          resultPost.post_data.post_id,
+          resultPost.post_data.post_id, 
           true,
-          req.api.userId)
-      }
-      
-      if(newPostData.referenced_post_id) {
-        let referencedPost = await postService.getPostData(
-          newPostData.referenced_post_id,
-          false,
-          req.api.userId)
-        newPostData.referenced_post = referencedPost
+          req.api.userId
+        )
+        if (newPostData.referenced_post_id) {
+          let referencedPost = await postService.getPostData(
+            newPostData.referenced_post_id,
+            false,
+            req.api.userId
+          )
+          newPostData.referenced_post = referencedPost
+          newPostData.referenced_post.liked_by_user = !!newPostData.referenced_post.liked_by_user
+        } else {
+          newPostData.referenced_post = null
+        }
+        delete newPostData.referenced_post_id
+        newPostData.liked_by_user = !!newPostData.liked_by_user
       }
       //END Retrieve post data.
 

--- a/src/scripts/db.sql
+++ b/src/scripts/db.sql
@@ -123,7 +123,7 @@ create table if not exists posts (
     cloudinary_id varchar(100),
     referenced_post_id int unsigned,
     post_type varchar(50) not null,
-    like_counter int unsigned not null default 1,
+    like_counter int unsigned not null default 0,
     created_at date default curdate(),
     
     foreign key(user_id) references users(id)

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -315,6 +315,7 @@ module.exports = {
         posts.post_type,
         posts.like_counter,
         posts.created_at,
+        true as liked_by_user,
         case 
           when posts.post_type = 'group' then (
             select user_groups.name
@@ -344,13 +345,13 @@ module.exports = {
       inner join favorite_posts
         on posts.id = favorite_posts.post_id
       where favorite_posts.user_id = ?
-      order by posts.created_at desc
+      order by posts.created_at desc, posts.id desc
       limit ?, ?;
     `
     // Prepare query to counts how much records there are.
     let countQuery = query.split('\n')
     // Remove selected fields and select the amount of records.
-    countQuery.splice(2, 33, 'count(*) as total_records')
+    countQuery.splice(2, 34, 'count(*) as total_records')
     // Remove limit to select all the records.
     countQuery.pop(); countQuery.pop()
     countQuery = countQuery.join('\n')


### PR DESCRIPTION
Changes:
- Replace 0,1 to false, true in _liked_by_user_ field, this was made in the controller.
- Like counter of a new post changed to 0.
- In every endpoint which returns a post/posts is added the  _liked_by_user_ field (this was updated in 'Get favorite posts' and 'Create a new post (user/group)' endpoints)
- Deleted _referenced_post_id_ of the response when a new post is created (of type user and group)

Run the following sql command:
`alter table posts
modify column like_counter int unsigned not null default 0;`