### PR TITLE
User search and group search APIs updated

### DIFF
--- a/docs/WEB_SERVICES.md
+++ b/docs/WEB_SERVICES.md
@@ -306,9 +306,10 @@ POST
 ##### Description
 
 Performs a search of a certain relative kind of user, based on the user that ask for the search. It can retrieve 
-all of users, followers or users followed by the requesting user that match with a search criteria. If the search 
-field is empty, the records are not discriminated. Records are served into groups of a certain size called pages. 
-You can select the group size and what group get in a call.
+all of users, followers or users followed by the requesting user that match with a search criteria. The 'all' user 
+relative type does not need user authentication. If the search field is empty, the records are not discriminated. 
+Records are served into groups of a certain size called pages. You can select the group size and what group get in 
+a call.
 
 This endpoint also return how much records were found with the search criteria.
 
@@ -319,6 +320,8 @@ This endpoint also return how much records were found with the search criteria.
 ##### Headers
 
 * `Authorization`
+
+It is optional when `user_relative_type` parameter is equals to 'all'.
 
 ##### Method
 
@@ -530,10 +533,11 @@ GET
 
 ##### Description
 
-Performs a search of certain relative kind of group, based on the user that ask for the search. It can retrieve all the public 
-groups or only the groups (public and private) that user belongs to, that match with a search criteria. If the search field is 
-empty the records are not discriminated. Records are served in groups of a certain size (determined by offset) called pages. You 
-can select the offset size and what page get in a call.
+Performs a search of certain relative kind of group, based on the user that ask for the search. It can retrieve all groups 
+or only the groups (public and private) that user belongs to, that match with a search criteria. The 'all' group relative 
+type does not need user authentication. If the search field is empty the records are not discriminated. Records are served 
+in groups of a certain size (determined by offset) called pages. You can select the offset size and what page get in a call.
+
 This endpoint also return how much records were found with the search criteria.
 
 ##### Endpoint
@@ -543,6 +547,8 @@ This endpoint also return how much records were found with the search criteria.
 ##### Headers
 
 * `Authorization`
+
+It is optional when `group_relative_type` parameter is equals to 'all'.
 
 ##### Method
 

--- a/docs/WEB_SERVICES.md
+++ b/docs/WEB_SERVICES.md
@@ -275,7 +275,7 @@ POST
   "post_type": "user",
   "like_counter": 1,
   "created_at": "2021-08-05T05:00:00.000Z",
-  "liked_by_user": 0,
+  "liked_by_user": false,
   "group_name": null,
   "group_id": null,
   "referenced_post_id": 9,
@@ -290,7 +290,7 @@ POST
     "post_type": "group",
     "like_counter": 1,
     "created_at": "2021-07-18T05:00:00.000Z",
-    "liked_by_user": 0,
+    "liked_by_user": false,
     "group_name": "Grupo 1 del usuario 1",
     "group_id": 1
   }
@@ -844,7 +844,7 @@ POST
   "post_type": "group",
   "like_counter": 1,
   "created_at": "2021-08-05T05:00:00.000Z",
-  "liked_by_user": 0,
+  "liked_by_user": false,
   "group_name": "Grupo 1 del usuario 1",
   "group_id": 1,
   "referenced_post_id": 105,
@@ -859,7 +859,7 @@ POST
     "post_type": "user",
     "like_counter": 1,
     "created_at": "2021-08-05T05:00:00.000Z",
-    "liked_by_user": 0,
+    "liked_by_user": false,
     "group_name": null,
     "group_id": null
   }
@@ -963,7 +963,7 @@ The number of the group to retrieve. Pages starts at `0`, what is also the defau
       "post_type": "user",
       "like_counter": 1,
       "created_at": "2021-07-18T05:00:00.000Z",
-      "liked_by_user": 0,
+      "liked_by_user": false,
       "group_name": null,
       "group_id": null,
       "referenced_post": {
@@ -977,7 +977,7 @@ The number of the group to retrieve. Pages starts at `0`, what is also the defau
         "post_type": "user",
         "like_counter": 1,
         "created_at": "2021-07-18T05:00:00.000Z",
-        "liked_by_user": 1,
+        "liked_by_user": true,
         "group_name": null,
         "group_id": null
       }
@@ -993,7 +993,7 @@ The number of the group to retrieve. Pages starts at `0`, what is also the defau
       "post_type": "group",
       "like_counter": 1,
       "created_at": "2021-07-12T05:00:00.000Z",
-      "liked_by_user": 1,
+      "liked_by_user": true,
       "group_name": "Random group",
       "group_id": 1,
       "referenced_post": null
@@ -1049,7 +1049,7 @@ Publication that the user is requesting.
   "post_type": "user",
   "like_counter": 1,
   "created_at": "2021-07-18T05:00:00.000Z",
-  "liked_by_user": 0,
+  "liked_by_user": false,
   "group_name": null,
   "group_id": null,
   "referenced_post": {
@@ -1063,7 +1063,7 @@ Publication that the user is requesting.
     "post_type": "user",
     "like_counter": 1,
     "created_at": "2021-07-18T05:00:00.000Z",
-    "liked_by_user": 1,
+    "liked_by_user": true,
     "group_name": null,
     "group_id": null
 }
@@ -1315,7 +1315,7 @@ The number of the group to retrieve. Pages starts at `0`, what is also the defau
         "post_type": "user",
         "like_counter": 1,
         "created_at": "2021-08-07T05:00:00.000Z",
-        "liked_by_user": 0,
+        "liked_by_user": false,
         "group_name": null,
         "group_id": null
       }
@@ -1361,7 +1361,7 @@ The number of the group to retrieve. Pages starts at `0`, what is also the defau
         "post_type": "group",
         "like_counter": 1,
         "created_at": "2021-08-08T05:00:00.000Z",
-        "liked_by_user": 0,
+        "liked_by_user": false,
         "group_name": "Group 1 of user 1",
         "group_id": 1
       }

--- a/docs/services/GROUP.md
+++ b/docs/services/GROUP.md
@@ -83,7 +83,7 @@ Return information of a group such as who is its owner, name, image, permissions
 
 * **Description**
 
-Return all the public groups or only the groups (public and private) that user belongs to.
+Return all groups or only the groups (public and private) that user belongs to.
 
 * **Params**:
   * `groupRelativeType`: string.

--- a/src/apis/social_network/controllers/groups.controller.js
+++ b/src/apis/social_network/controllers/groups.controller.js
@@ -26,14 +26,22 @@ module.exports = {
   },
   
   searchGroups: async function(req, res) {
+    const groupRelativeType = req.query.group_relative_type
+    const userId = req.api.userId
+    if (groupRelativeType == 'user' && !userId) {
+      return res.status(401).finish({
+        code: 1,
+        messages: ['User unauthenticated']
+      })
+    }
     try {
       let result = await groupService.searchGroups(
-        req.query.group_relative_type,
+        groupRelativeType,
         req.query.search,
         req.query.offset,
         req.query.page,
         req.query.asc,
-        req.api.userId
+        userId
       )
 
       res.finish({

--- a/src/apis/social_network/controllers/users.controller.js
+++ b/src/apis/social_network/controllers/users.controller.js
@@ -194,14 +194,23 @@ module.exports = {
   },
   
   searchUsers: async function(req, res) {
+    const userRelativeType = req.query.user_relative_type
+    const userId = req.api.userId
+    if ((userRelativeType == 'followers' || userRelativeType == 'followed') && !userId) {
+      return res.status(401).finish({
+        code: 1,
+        messages: ['User unauthenticated.']
+      })
+    }
     try {
       let result = await userService.searchUsers(
-        req.query.user_relative_type, 
+        userRelativeType, 
         req.query.page, 
         req.query.offset, 
         req.query.search, 
         req.query.asc,
-        req.api.userId)
+        userId
+      )
 
       res.finish({
         code: 0,

--- a/src/apis/social_network/flows/groups.flow.js
+++ b/src/apis/social_network/flows/groups.flow.js
@@ -20,7 +20,7 @@ module.exports = {
 
   searchGroups: [
     generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
+    generalMiddleware.userAuthIfTokenSent,
     groupsMiddleware.checkSearchGroupsParams,
     groupsController.searchGroups
   ],

--- a/src/apis/social_network/flows/users.flow.js
+++ b/src/apis/social_network/flows/users.flow.js
@@ -41,7 +41,7 @@ module.exports = {
   
   searchUsers: [
     generalMidd.verifyAPIKey,
-    generalMidd.userAuth,
+    generalMidd.userAuthIfTokenSent,
     userMidd.checkSearchUserParams,
     userCtrl.searchUsers
   ],

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -232,8 +232,10 @@ module.exports = {
     }
   },
 
-  /** Perform a search in the database retrieving all the user records that match with 'search' parameter.
-   * It gets all users, followers or users followed by a target user. This can be set in 'userRelativeType' using: all|followers|followed
+  /** 
+   * Perform a search in the database retrieving all the user records that match with 'search' parameter.
+   * It gets all users, followers or users followed by a target user. This can be set in 'userRelativeType' using: all|followers|followed.
+   * The 'all' user relative type does not need user authentication.
    * It can selects chunks of records of 'offset' size. The chunk number is defined by 'page'.
    * It supports ascending and descending order by regiter date.
    * @param {string} userRelativeType 
@@ -257,8 +259,8 @@ module.exports = {
         users.profile_img_src
       from users
         inner join user_types
-          on users.user_type_id = user_types.id `
-    
+          on users.user_type_id = user_types.id
+    `
     if(userRelativeType != 'all') {
       query += `inner join followers `
       if(userRelativeType == 'followers') {
@@ -282,8 +284,8 @@ module.exports = {
       users.email regexp ? or
       user_types.name regexp ? ) 
       order by users.id ${asc ? 'asc' : 'desc'}
-      limit ?, ?;`
-    
+      limit ?, ?;
+    `
     let args = [ userTarget, search, search, search, search, search, page*offset, offset ]
     if(userRelativeType == 'all') {
       args.shift()


### PR DESCRIPTION
When 'all' relative type in both APIs is sent, its not mandatory the user authentication.

Documentation updated.

Little update not related to this PR: Change liked_by_user with boolean values in Web services docs