### PR TITLE
APIs to create comments in posts of type user and group implemented

### DIFF
--- a/docs/WEB_SERVICES.md
+++ b/docs/WEB_SERVICES.md
@@ -13,6 +13,7 @@
     * [Sign in](#sign-in)
     * [Get public user data](#get-public-user-data)
     * [Create user post](#create-user-post)
+    * [Create comment in user post](#create-comment-in-user-post)
     * [Search users](#search-users)
     * [Get public user types](#get-public-user-types)
     * [Get majors data](#get-majors-data)
@@ -300,6 +301,58 @@ POST
 ##### Codes
 * 1: No data was sent.
 * 2: The post cannot be shared, it belongs to a private group.
+
+#### Create comment in user post
+
+##### Description
+
+Creates a comment made on a post of type 'user'.
+
+The comment can has a content and/or image.
+
+##### Endpoint
+
+`/v1/api/social-network/users/post/:post_id/make-comment`
+
+##### Headers
+
+* `Content-Type`: multipart/form-data
+* `Authorization`
+
+##### Method
+
+POST
+
+##### Params
+
+* URl params
+  * `post_id`: int.
+
+* Body params
+  * `content`: string.
+  * `image`: blob.
+
+##### Response data-structure
+
+```json
+{
+  "post_id": 3,
+  "comment_id": 44,
+  "user_id": 31,
+  "firstname": "johndoe",
+  "lastname": "John",
+  "username": "Doe",
+  "profile_image_src": "",
+  "content": "Comment of John in post with id 3",
+  "image_src": "https://res.cloudinary.com/someone-cloud/image/upload/v1629060714/zlslbdbzu3fjyiknjm38.jpg",
+  "created_at": "2021-08-15"
+}
+```
+
+##### Codes
+* 1: No data was sent.
+* 2: Post does not exist.
+* 3: Error. This post belongs to a group. Use the proper API.
 
 #### Search users
 

--- a/docs/WEB_SERVICES.md
+++ b/docs/WEB_SERVICES.md
@@ -26,6 +26,7 @@
     * [Add a user to a group](#add-a-user-to-a-group)
     * [Get available permissions for groups](#get-available-permissions-for-groups)
     * [Create group post](#create-group-post)
+    * [Create comment in group post](#create-comment-in-group-post)
     * [Get membership information](#get-membership-information)
   * [Posts](#posts)
     * [Get posts for timeline](#get-posts-for-timeline)
@@ -925,6 +926,59 @@ POST
 * 3: No data was sent.
 * 4: User is not member of group.
 * 5: The post cannot be shared, it belongs to a private group.
+
+#### Create comment in group post
+
+##### Description
+
+Creates a comment made on a post of type 'group'.
+
+The comment can has a content and/or image.
+
+##### Endpoint
+
+`/v1/api/social-network/groups/post/:post_id/make-comment`
+
+##### Headers
+
+* `Content-Type`: multipart/form-data
+* `Authorization`
+
+##### Method
+
+POST
+
+##### Params
+
+* URl params
+  * `post_id`: int.
+
+* Body params
+  * `content`: string.
+  * `image`: blob.
+
+##### Response data-structure
+
+```json
+{
+  "post_id": 13,
+  "comment_id": 46,
+  "user_id": 31,
+  "firstname": "johndoe",
+  "lastname": "John",
+  "username": "Doe",
+  "profile_image_src": "",
+  "content": "Comment of John in post with id 13",
+  "image_src": "https://res.cloudinary.com/someone-cloud/image/upload/v1629063555/iphacdyujxixgljbq9bg.jpg",
+  "created_at": "2021-08-15"
+}
+```
+
+##### Codes
+* 1: The post does not exist or the post does not belong to a group.
+* 2: Group does not have [codename] permission.
+* 3: No data was sent.
+* 4: Forbidden. User cannot comment because does not belong to the group.
 
 #### Get membership information
 

--- a/docs/services/POST.md
+++ b/docs/services/POST.md
@@ -11,6 +11,7 @@
   * [getFavoritePosts](#getfavoriteposts)
   * [getCommentsOfAPost](#getcommentsofapost)
   * [getPostsOfAGroup](#getpostsofagroup)
+  * [createComment](#createcomment)
 
 ## Description
 
@@ -205,3 +206,24 @@ default.
     * `group_id`: string,
     * `referenced_post_id`: int
   * `total_records`: int. | undefined
+
+### `createComment`
+
+* **Description**: 
+
+Create a comment made on a certain post (user and group post type).
+
+* **Params**:
+
+  * `postId`: int.
+  * `userId`: int.
+  * `comment`: Object
+    * `content`: string
+    * `image`: Object
+      * `path`: string
+
+* **Return data type**: Promise\<Object>
+  * `comment_id`: number
+  * `content`: string 
+  * `image_src`: string.
+  * `created_at`: string

--- a/src/apis/social_network/endpoints/groups.endpoint.js
+++ b/src/apis/social_network/endpoints/groups.endpoint.js
@@ -10,5 +10,6 @@ router.post('/group/:group_id/add-user', groupsFlow.addUserToGroup)
 router.get('/available-permissions', groupsFlow.getAvailableGroupPermissions)
 router.post('/group/:group_id/post', groupsFlow.post)
 router.get('/group/:group_id/membership-info', groupsFlow.getMembershipInfo)
+router.post('/post/:post_id/make-comment', groupsFlow.createComment)
 
 module.exports = router

--- a/src/apis/social_network/endpoints/users.endpoint.js
+++ b/src/apis/social_network/endpoints/users.endpoint.js
@@ -8,5 +8,6 @@ router.post('/post', userflows.post)
 router.get('/search', userflows.searchUsers)
 router.get('/types', userflows.getPublicUserTypes)
 router.get('/majors', userflows.getMajorsData)
+router.post('/post/:post_id/make-comment', userflows.createComment)
 
 module.exports = router

--- a/src/apis/social_network/flows/groups.flow.js
+++ b/src/apis/social_network/flows/groups.flow.js
@@ -1,7 +1,8 @@
 const fileUpload = require('express-fileupload')
-const generalMiddleware = require('../../../middlewares/general.middleware')
-const groupsController = require('../controllers/groups.controller')
-const groupsMiddleware = require('../../../middlewares/groups.middleware')
+const generalMidd = require('../../../middlewares/general.middleware')
+const groupMidd = require('../../../middlewares/groups.middleware')
+const postMidd = require('../../../middlewares/posts.middleware')
+const groupCtrl = require('../controllers/groups.controller')
 
 const rootDir = process.env.ACADEMIC_NETWORK_BACKEND_ROOTDIR
 // FileUpload settings.
@@ -13,68 +14,79 @@ const fileUploadMidd = fileUpload({
 
 module.exports = {
   getGroupInformation: [
-    generalMiddleware.verifyAPIKey,
-    groupsMiddleware.checkGroupId,
-    groupsController.getGroupInformation
+    groupMidd.checkGroupId,
+    generalMidd.verifyAPIKey,
+    groupCtrl.getGroupInformation
   ],
 
   searchGroups: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuthIfTokenSent,
-    groupsMiddleware.checkSearchGroupsParams,
-    groupsController.searchGroups
+    generalMidd.verifyAPIKey,
+    groupMidd.checkSearchGroupsParams,
+    generalMidd.userAuthIfTokenSent,
+    groupCtrl.searchGroups
   ],
 
   createGroup: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
-    groupsMiddleware.checkCreatingData,
-    groupsController.createGroup
+    generalMidd.verifyAPIKey,
+    groupMidd.checkCreatingData,
+    generalMidd.userAuth,
+    groupCtrl.createGroup
   ],
 
   switchGroupNotifications: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
-    groupsMiddleware.checkGroupId,
-    groupsMiddleware.checkSwitchGroupNotificationsData,
-    groupsController.switchGroupNotifications
+    generalMidd.verifyAPIKey,
+    groupMidd.checkGroupId,
+    generalMidd.userAuth,
+    groupMidd.checkSwitchGroupNotificationsData,
+    groupCtrl.switchGroupNotifications
   ],
 
   updateGroupImage: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
-    groupsMiddleware.checkGroupId,
+    generalMidd.verifyAPIKey,
+    groupMidd.checkGroupId,
+    generalMidd.userAuth,
+    groupMidd.checkUpdateGroupImageData,
     fileUploadMidd,
-    groupsMiddleware.checkUpdateGroupImageData,
-    groupsController.updateGroupImage
+    groupCtrl.updateGroupImage
   ],
 
   addUserToGroup: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
-    groupsMiddleware.checkGroupId,
-    groupsController.addUserToGroup
+    generalMidd.verifyAPIKey,
+    groupMidd.checkGroupId,
+    generalMidd.userAuth,
+    groupCtrl.addUserToGroup
   ],
 
   getAvailableGroupPermissions: [
-    generalMiddleware.verifyAPIKey,
-    groupsController.getAvailableGroupPermissions
+    generalMidd.verifyAPIKey,
+    groupCtrl.getAvailableGroupPermissions
   ],
 
   post: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
-    groupsMiddleware.checkGroupId,
-    groupsMiddleware.verifyPermissions,
+    generalMidd.verifyAPIKey,
+    groupMidd.checkGroupId,
+    generalMidd.userAuth,
+    groupMidd.verifyPermissions,
+    groupMidd.checkNewPostData,
     fileUploadMidd,
-    groupsMiddleware.checkNewPostData,
-    groupsController.createPost
+    groupCtrl.createPost
   ],
 
   getMembershipInfo: [
-    generalMiddleware.verifyAPIKey,
-    generalMiddleware.userAuth,
-    groupsMiddleware.checkGroupId,
-    groupsController.getMembershipInfo
+    generalMidd.verifyAPIKey,
+    groupMidd.checkGroupId,
+    generalMidd.userAuth,
+    groupCtrl.getMembershipInfo
+  ],
+
+  createComment: [
+    generalMidd.verifyAPIKey,
+    generalMidd.userAuth,
+    postMidd.checkPostId,
+    groupMidd.getGroupIdFromPostId,
+    groupMidd.verifyPermissions,
+    fileUploadMidd,
+    postMidd.checkCommentInPostData,
+    groupCtrl.createComment
   ]
 }

--- a/src/apis/social_network/flows/users.flow.js
+++ b/src/apis/social_network/flows/users.flow.js
@@ -1,6 +1,7 @@
 const fileUpload = require('express-fileupload')
 const generalMidd = require('../../../middlewares/general.middleware')
 const userMidd = require('../../../middlewares/users.middleware')
+const postMidd = require('../../../middlewares/posts.middleware')
 const userCtrl = require('../controllers/users.controller')
 
 const rootDir = process.env.ACADEMIC_NETWORK_BACKEND_ROOTDIR
@@ -54,5 +55,14 @@ module.exports = {
   getMajorsData: [
     generalMidd.verifyAPIKey,
     userCtrl.getMajorsData
+  ],
+
+  createComment: [
+    generalMidd.verifyAPIKey,
+    generalMidd.userAuth,
+    postMidd.checkPostId,
+    fileUploadMidd,
+    postMidd.checkCommentInPostData,
+    userCtrl.createComment
   ]
 }

--- a/src/middlewares/posts.middleware.js
+++ b/src/middlewares/posts.middleware.js
@@ -41,5 +41,36 @@ module.exports = {
       })
     }
     next()
+  },
+
+  checkCommentInPostData: function(req, res, next) {
+    let validator = new Validator()
+    validator(req.body.content).isString().display('content')
+
+    // FileUploader will use the 'image'-named field, if a file is sent in this field FileUploader
+    // will "send the image" in req.files.image so req.body.image will have undefined value, but 
+    // if a file is not sent in the field 'image' req.files.image will be undefined and 
+    // req.body.image will have a value so it is necessary to validate it.
+    //If no file is sent, req.files will be undefined as well.
+    if (!req.files) {
+      req.files = {}
+    }
+    validator(req.files.image).isObject().display('image')
+    if (req.body.image) {
+      validator(req.body.image).isObject().display('image')
+    }
+    
+    let errors = parseValidatorOutput(validator.run())
+    if (errors.length != 0) {
+      if (req.files.image) {
+        fs.unlinkSync(req.files.image.path)
+      }
+      return res.status(400).finish({
+        code: -1,
+        messages: errors
+      })
+    }
+    
+    next()
   }
 }

--- a/src/scripts/db.sql
+++ b/src/scripts/db.sql
@@ -135,6 +135,7 @@ create table if not exists post_comments (
     user_id int unsigned not null,
     content text,
     image_src varchar(700),
+    cloudinary_id varchar(100),
     created_at date default curdate(),
     
     foreign key(post_id) references posts(id),

--- a/src/scripts/db_initial_setup.sql
+++ b/src/scripts/db_initial_setup.sql
@@ -28,4 +28,5 @@ call group_permission_create("Permitir publicaciones", "allow_posts");
 call group_permission_create("Permitir comentarios", "allow_comments");
 
 -- Creates permissions for endpoints.
-call endpoint_permission_create("/v1/api/social-network/groups/group/:group_id/post", 1);
+call endpoint_permission_create("/v1/api/social-network/groups/group/:number/post", 1);
+call endpoint_permission_create("/v1/api/social-network/groups/post/:number/make-comment", 2);

--- a/src/services/group.service.js
+++ b/src/services/group.service.js
@@ -117,6 +117,7 @@ module.exports = {
     
     try {
       let permissions = await mariadb.query(query, [groupId])
+      delete permissions.meta
       let exists_group = true
 
       //Verify if group exists.


### PR DESCRIPTION
Endpoints to test it:
* `/v1/api/social-network/users/post/:post_id/make-comment`
* `/v1/api/social-network/groups/post/:post_id/make-comment`

Recreate the table `post_comments` or only add the following field to the table with: 
`ALTER TABLE post_comments ADD cloudinary_id_test varchar(100);`

In the db initial setup was modified one record and inserted a new one, make sure to run it with:

* `call endpoint_permission_create("/v1/api/social-network/groups/group/:number/post", 1);`
* `call endpoint_permission_create("/v1/api/social-network/groups/post/:number/make-comment", 2);`
